### PR TITLE
split docker envs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.6/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "catalog-svc",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/home/api",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+    "terminal.integrated.defaultProfile.linux": "zsh"
+  },
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+    "ms-python.python"
+  ],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "api"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@ README.md
 __pycache__/
 __pypackages__/
 .pytest_cache/
-.devcontainer/
 .ipython/
 Dockerfile
 media/

--- a/Dockerfile-prd
+++ b/Dockerfile-prd
@@ -29,23 +29,16 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ## add and install requirements
 RUN pip install --upgrade pip
 COPY ./requirements .
-RUN pip install -r dev.txt
+RUN pip install -r prod.txt
 
 
 ## build-image
 FROM python:3.10-alpine AS runtime-image
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    HOME=/home/api \
-    PATH="/opt/venv/bin:$PATH" \
-    LIBRARY_PATH=/lib:/usr/lib \
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 HOME=/home/api PATH="/opt/venv/bin:$PATH" LIBRARY_PATH=/lib:/usr/lib
 
 ## copy Python dependencies from build image
 COPY --from=compile-image /opt/venv /opt/venv
-
 
 
 ## install dependencies
@@ -57,35 +50,17 @@ RUN apk update && \
     apk add --no-cache libwebp-dev && \
     apk add --no-cache libpng-dev && \
     apk add --no-cache tiff-dev && \
-    apk add --no-cache git && \
-    apk add --no-cache git-flow && \
-    apk add --no-cache curl && \
-    apk add --no-cache wget && \
-    apk add --no-cache vim && \
-    apk add --no-cache zsh && \
-    apk add --no-cache openjdk8-jre && \
     apk add --no-cache --virtual .build-deps build-base linux-headers && \
     rm -rf /var/cache/apk/*
+
 
 ## add user
 RUN adduser -D api
 USER api:api
 WORKDIR $HOME
-
-RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.2/zsh-in-docker.sh)" -- \
-    -t "ys" \
-    -p git \
-    -p git-flow \
-    -p https://github.com/zsh-users/zsh-completions \
-    -p https://github.com/zsh-users/zsh-autosuggestions \
-    -p https://github.com/zdharma/fast-syntax-highlighting \
-    -a "export TERM=xterm-256color"
-
-
-COPY --chown=api:api ./entrypoint.sh $HOME//entrypoint.sh
-COPY --chown=api:api ./start.sh $HOME/start.sh
-COPY --chown=api:api ./gitconfig $HOME/.gitconfig
+COPY --chown=api:api . $HOME
+COPY --chown=api:api ./start-gunicorn.sh /start-gunicorn.sh
 
 EXPOSE 5000
-ENTRYPOINT [ "/home/api/entrypoint.sh" ]
+ENTRYPOINT [ "/start-gunicorn.sh" ]
 

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ clean:
 
 
 clean-build: clean
-	rm --force --recursive build/
-	rm --force --recursive dist/
-	rm --force --recursive *.egg-info
+	rm -rf build/
+	rm -rf dist/
+	rm -rf *.egg-info
 
 lint:
 	@flake8 ${FLAKE8_FLAGS} .

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,15 @@
+21/04/2022
+
+- [ ] Se puder usar pipenv, poetry ou pdm no projeto será muito benefíco, porque o pip porque se só dificulta o manuseio das dependências, mesmo criando arquivos separados como dev.txt, prop.txt e etc. Quando instalamos uma dependência, temos que ter cuidado em qual arquivo ela estará e isto aumentar a chance de vários erros em gerenciar as dependências.
+
+- [ ] Separe Dockerfile de desenvolvimento e produção. O ambiente de desenvolvimento pode ser mais flexível, ter ferramentas e configurações para ajudar no desenvolvimento, enquanto a imagem de produção ficaria mais otimista até trabalhando-se com multi-stage e usando pacotes wheels com pip para gerar uma imagem menor.
+
+- [ ] Importante também que no ambiente de desenvolvimento ao rodar "docker-compose up" tudo já suba de uma vez e a aplicação já estava disponível.
+
+- [ ] Gere o venv dentro do próprio projeto, isto ajuda as IDE a entenderem os pacotes instalados, mesmo quando não estão conectadas com Docker.
+
+- [ ] Imagem Python do tipo slim tem tipo melhor desempenho para executar o Python e acabam até ficando menores em produção.
+
+- [ ] Usar o Pydantic para embutir a validação na própria entidade pode ser uma ideia muito interessante, já simplifica a validação no mesmo arquivo, porém o Pydantic tem problemas com validação alinhadas de subclasses, entre outras coisas, então tornar esta dependência dele direta para as entidades pode causar causar bug e dificuldades para manutenções posteriores, além de engessar a validação do domínio somente ao Pydantic. Use-o com bastante discernimento.
+
+- [ ] Tenha como entre últimas opções usar libs externas dentro do domínio, ao fazer isto e romper o limite arquitetural tenha em mente as vantagens e desvantagens de tal ato.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: /start.sh
+    command: /home/api/start.sh
     ports:
       - "5000:5000"
     stdin_open: true

--- a/infra/dev/gunicorn.py
+++ b/infra/dev/gunicorn.py
@@ -1,0 +1,20 @@
+"""Gunicorn *development* config file"""
+
+# Django WSGI application path in pattern MODULE_NAME:VARIABLE_NAME
+wsgi_app = "main.wsgi:application"
+# The granularity of Error log outputs
+loglevel = "debug"
+# The number of worker processes for handling requests
+workers = 2
+# The socket to bind
+bind = "0.0.0.0:8000"
+# Restart workers when code changes (development only!)
+reload = True
+# Write access and error info to /var/log
+accesslog = errorlog = "/var/log/gunicorn/dev.log"
+# Redirect stdout/stderr to log file
+capture_output = True
+# PID file so you can easily fetch process ID
+pidfile = "/var/run/gunicorn/dev.pid"
+# Daemonize the Gunicorn process (detach & enter background)
+daemon = True

--- a/infra/prod/gunicorn.py
+++ b/infra/prod/gunicorn.py
@@ -1,0 +1,19 @@
+"""Gunicorn *production* config file"""
+
+import multiprocessing
+
+# Django WSGI application path in pattern MODULE_NAME:VARIABLE_NAME
+wsgi_app = "main.wsgi:application"
+# The number of worker processes for handling requests
+workers = multiprocessing.cpu_count() * 2 + 1
+# The socket to bind
+bind = "0.0.0.0:8000"
+# Write access and error info to /var/log
+accesslog = "/var/log/gunicorn/access.log"
+errorlog = "/var/log/gunicorn/error.log"
+# Redirect stdout/stderr to log file
+capture_output = True
+# PID file so you can easily fetch process ID
+pidfile = "/var/run/gunicorn/prod.pid"
+# Daemonize the Gunicorn process (detach & enter background)
+daemon = True

--- a/infra/prod/nginx.conf
+++ b/infra/prod/nginx.conf
@@ -1,0 +1,13 @@
+server_tokens               off;
+access_log                  /var/log/nginx/supersecure.access.log;
+error_log                   /var/log/nginx/supersecure.error.log;
+
+# This configuration will be changed to redirect to HTTPS later
+server {
+  server_name               .supersecure.codes;
+  listen                    80;
+  location / {
+    proxy_pass              http://localhost:8000;
+    proxy_set_header        Host $host;
+  }
+}

--- a/start-gunicorn.sh
+++ b/start-gunicorn.sh
@@ -1,6 +1,41 @@
 #!/bin/sh
 set -e
 
+if [ -z "${POSTGRES_USER}" ]; then
+    base_postgres_image_default_user='postgres'
+    export POSTGRES_USER="${base_postgres_image_default_user}"
+fi
+
+postgres_ready() {
+python << END
+import sys
+import psycopg2
+try:
+    psycopg2.connect(
+        dbname="${POSTGRES_DB}",
+        user="${POSTGRES_USER}",
+        password="${POSTGRES_PASSWORD}",
+        host="${POSTGRES_HOST}",
+        port="${POSTGRES_PORT}",
+    )
+except psycopg2.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+END
+}
+
+until postgres_ready; do
+  >&2 echo 'Waiting for PostgreSQL to become available...'
+  echo ${POSTGRES_DB} ${POSTGRES_USER} ${POSTGRES_PASSWORD} ${POSTGRES_HOST}
+  sleep 1
+done
+>&2 echo 'PostgreSQL is available'
+
+echo "Collect static files. "
+python manage.py collectstatic --noinput
+
+echo "Compile translations."
+python manage.py compilemessages
 
 echo "Running gunicorn"
-python manage.py runserver 5000
+gunicorn --access-logfile - --bind 0.0.0.0:5000 main.wsgi:application


### PR DESCRIPTION
Fala Luiz beleza.

Aos poucos vou corrigindo os problemas que aconteceram.

- [ ] Se puder usar pipenv, poetry ou pdm no projeto será muito benefíco, porque o pip porque se só dificulta o manuseio das dependências, mesmo criando arquivos separados como dev.txt, prop.txt e etc. Quando instalamos uma dependência, temos que ter cuidado em qual arquivo ela estará e isto aumentar a chance de vários erros em gerenciar as dependências.

R:  Tentei por 2x utilizar o pdm como gerenciador e não gostei. Por hora estou utilizando o pip antigo e devo migrar para o poetry

- [ ] Separe Dockerfile de desenvolvimento e produção. O ambiente de desenvolvimento pode ser mais flexível, ter ferramentas e configurações para ajudar no desenvolvimento, enquanto a imagem de produção ficaria mais otimista até trabalhando-se com multi-stage e usando pacotes wheels com pip para gerar uma imagem menor.

R: fiz essa separação hoje tenho Dockerfile-prd e o dockerfile como dev

- [ ] Importante também que no ambiente de desenvolvimento ao rodar "docker-compose up" tudo já suba de uma vez e a aplicação já estava disponível.

R: Esta assim. falta alguns ajustes do zsh, gitconfig e alguns pacotes de lint

- [ ] Gere o venv dentro do próprio projeto, isto ajuda as IDE a entenderem os pacotes instalados, mesmo quando não estão conectadas com Docker.

R: Feito.

- [ ] Imagem Python do tipo slim tem tipo melhor desempenho para executar o Python e acabam até ficando menores em produção.

R: Vou migrar para o slim em ambiente de dev e alpine para prd. O que eu fiz foi apenas customizar o alpine para ser aprovado no desafio

- [ ] Usar o Pydantic para embutir a validação na própria entidade pode ser uma ideia muito interessante, já simplifica a validação no mesmo arquivo, porém o Pydantic tem problemas com validação alinhadas de subclasses, entre outras coisas, então tornar esta dependência dele direta para as entidades pode causar causar bug e dificuldades para manutenções posteriores, além de engessar a validação do domínio somente ao Pydantic. Use-o com bastante discernimento.

R: migrando para o serializers conforme o plano de estudos

- [ ] Tenha como entre últimas opções usar libs externas dentro do domínio, ao fazer isto e romper o limite arquitetural tenha em mente as vantagens e desvantagens de tal ato.

R: comecei a estudar o DDD e o clean e realmente faz sentido não ter bibliotecas externas ali na pasta src/ (responsavel pela logica fora do framework)


Obrigado pelo feeedback e vou ajustando as coisas a medida que a api for evoluindo,
